### PR TITLE
Disabled by default and no auto pause when not in use.

### DIFF
--- a/reds/CP77-External-Radio.reds
+++ b/reds/CP77-External-Radio.reds
@@ -32,7 +32,7 @@ let auxRadioEnabled: Bool;
 
 @wrapMethod(PlayerPuppet)
 protected cb func OnGameAttached() -> Bool {
-    this.auxRadioEnabled = true;
+    this.auxRadioEnabled = false;
     return wrappedMethod();
 }
 
@@ -56,18 +56,20 @@ protected func Activate() -> Void {
         Log("[External Radio] Radio station selected, enabling");
         this.m_quickSlotsManager.SendRadioEvent(false, false, -1);
         player.auxRadioEnabled = true;
-    } else {
-        player.auxRadioEnabled = false;
+        play();
+    } else { 
+        if (player.auxRadioEnabled) {
+            player.auxRadioEnabled = false;
+            pause();
+        }
         wrappedMethod();
     }
-    if (player.auxRadioEnabled) { play(); }
-    else { pause(); }
 }
 
 @wrapMethod(VehicleComponent)
 protected cb func OnVehicleRadioEvent(evt: ref<VehicleRadioEvent>) -> Bool {
     let ret = wrappedMethod(evt);
-    if (this.m_radioState) {
+    if (this.m_radioState && GetPlayer(this.GetVehicle().GetGame()).auxRadioEnabled) {
         Log("[External Radio] Radio change detected, disabling");
         GetPlayer(this.GetVehicle().GetGame()).auxRadioEnabled = false;
         pause();


### PR DESCRIPTION
Heya! Love the mod and decided to make a few changes to the script that I think you'd like. 

Basically I didn't want it to always send a pause command if I wasn't using the AUX station. (Example: Watching youtube/twitch, change station, it'd pause the video).

The other change was that I didn't want it on by default when jumping into a new vehicle.

One thing I couldn't figure out: how to get it to play the AUX station from another station without having to go to disable the radio first. I don't know where any of the game's commands can be found so I just left it as is.

Thanks for your work!
